### PR TITLE
fix(kyberlib): :bug: Using outdated edition for no reason

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "kyberlib"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "aes",
  "cc",
@@ -992,9 +992,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1002,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1027,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1040,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ build = "build.rs"
 categories = ["algorithms", "cryptography", "wasm", "no-std"]
 description = "A Robust Rust Library for CRYSTALS-Kyber Post-Quantum Cryptography."
 documentation = "https://docs.rs/kyberlib"
-edition = "2018"
+edition = "2021"
 exclude = [
     "/.git/*",
     "/.github/*",
@@ -27,14 +27,15 @@ license = "MIT OR Apache-2.0"
 name = "kyberlib"
 readme = "README.md"
 repository = "https://github.com/sebastienrousseau/kyberlib"
-version = "0.0.2"
+rust-version = "1.71.1"
+version = "0.0.3"
 
 [dependencies]
 aes = { version = "0.8.3", optional = true }
 ctr = { version = "0.9.2", optional = true }
 rand_core = { version = "0.6.4",  default-features = false }
 sha2 = { version = "0.10.8", optional = true , default-features = false }
-wasm-bindgen = { version = "0.2.88", optional = true }
+wasm-bindgen = { version = "0.2.89", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
@@ -49,8 +50,8 @@ optional = true
 benchmarking = ["criterion"]
 
 [build-dependencies]
-cc = {version = "1.0.73", optional = true }
-nasm-rs = {version = "0.2.4", optional = true }
+cc = {version = "1.0.83", optional = true }
+nasm-rs = {version = "0.2.5", optional = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
this crate requires at least Rust 1.71, which is newer than the last 2018-edition compiler