### PR TITLE
chore(release): prepare v0.0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68  # v2 (HEAD as of 2026-05-20)
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2 (HEAD as of 2026-05-20)
         with:
           tool: cargo-llvm-cov
       - name: Run coverage gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ with the pre-1.0 caveat that the **patch** number is the breaking-change axis:
 `0.0.x` → `0.0.(x+1)` may break source compatibility. See `SECURITY.md` for the
 versioning and support policy.
 
+## [0.0.9] - 2026-08-03
+
+### Security
+
+- Replaced the vulnerable `atty` transitive dependency used by the
+  dudect benchmark harness with an MSRV-compatible compatibility crate
+  backed by the sound standard-library `IsTerminal` API.
+- Pinned `zeroize_derive` to 1.4.2 so the declared Rust 1.74 MSRV can
+  parse and build the complete locked dependency graph.
+
+### Changed
+
+- Updated workspace and inter-crate versions to 0.0.9.
+
 ## [0.0.8] — 2026-07-24
 
 (Work for the next milestones lives on `feat/v0.0.8-byoe` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-trait"
@@ -106,14 +106,7 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
+version = "0.2.15"
 
 [[package]]
 name = "autocfg"
@@ -685,15 +678,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -762,7 +746,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -802,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "kyberlib"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "aes",
  "cc",
@@ -823,11 +807,11 @@ dependencies = [
 
 [[package]]
 name = "kyberlib-asm"
-version = "0.0.8"
+version = "0.0.9"
 
 [[package]]
 name = "kyberlib-hybrid"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "kyberlib",
  "rand 0.8.6",
@@ -838,14 +822,14 @@ dependencies = [
 
 [[package]]
 name = "kyberlib-pkcs8"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "kyberlib",
 ]
 
 [[package]]
 name = "kyberlib-wasm"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "criterion",
  "getrandom 0.2.15",
@@ -1920,18 +1904,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.9.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.5.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/atty-compat",
     "crates/kyberlib",
     "crates/kyberlib-asm",
     "crates/kyberlib-hybrid",
@@ -32,7 +33,7 @@ homepage     = "https://kyberlib.com"
 license      = "MIT OR Apache-2.0"
 repository   = "https://github.com/sebastienrousseau/kyberlib"
 rust-version = "1.74"
-version      = "0.0.8"
+version      = "0.0.9"
 
 # Shared dependency pins. Members inherit via `dep = { workspace = true }`.
 [workspace.dependencies]
@@ -62,6 +63,12 @@ insta            = { version = "1.40", features = ["yaml"] }
 # `default-features = false` keeps the ctgrind backend off (we use the
 # native counter-based timing).
 dudect-bencher   = { version = "0.7" }
+
+[patch.crates-io]
+# clap 2 (through dudect-bencher) only needs atty's three-stream API.
+# This MSRV-compatible shim implements that API with Rust's sound
+# `std::io::IsTerminal`, removing RUSTSEC-2021-0145 from the graph.
+atty = { path = "crates/atty-compat" }
 
 # Workspace-level lints. Members opt in with `[lints] workspace = true`.
 # Specific lints carry explicit positive priority so they override the

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 
 ```toml
 [dependencies]
-kyberlib = "0.0.8"
+kyberlib = "0.0.9"
 ```
 
 You need [Rust](https://rustup.rs/) stable ≥ 1.74 (the declared MSRV).
@@ -94,7 +94,7 @@ satellite crates each have their own channels (see
 
 ```toml
 [dependencies]
-kyberlib = { version = "0.0.8", default-features = false, features = ["kyber768"] }
+kyberlib = { version = "0.0.9", default-features = false, features = ["kyber768"] }
 ```
 
 Requires `alloc` (because of `Vec` buffers in the rejection sampler).
@@ -164,7 +164,7 @@ application needs.
 ```toml
 # Example: production server with x86_64 SIMD acceleration
 [dependencies]
-kyberlib = { version = "0.0.8", features = ["avx2"] }
+kyberlib = { version = "0.0.9", features = ["avx2"] }
 ```
 
 ---
@@ -262,7 +262,7 @@ migration paths:
 -[dependencies]
 -kyberlib = "0.0.6"
 +[dependencies]
-+kyberlib = "0.0.8"
++kyberlib = "0.0.9"
 ```
 
 ```diff
@@ -286,7 +286,7 @@ with every other FIPS 203 endpoint.
 -[dependencies]
 -pqcrypto-kyber = "0.8"
 +[dependencies]
-+kyberlib = "0.0.8"
++kyberlib = "0.0.9"
 ```
 
 ```diff
@@ -311,7 +311,7 @@ key material.
 -[dependencies]
 -ml-kem = "0.3"
 +[dependencies]
-+kyberlib = "0.0.8"
++kyberlib = "0.0.9"
 ```
 
 ```diff
@@ -335,7 +335,7 @@ differences listed in [`doc/COMPARISON.md`](doc/COMPARISON.md).
 -[dependencies]
 -libcrux-ml-kem = "0.0"
 +[dependencies]
-+kyberlib = "0.0.8"
++kyberlib = "0.0.9"
 ```
 
 Function-name table:
@@ -360,7 +360,7 @@ formal-verification provenance.
 -[dependencies]
 -oqs = "0.10"
 +[dependencies]
-+kyberlib = "0.0.8"
++kyberlib = "0.0.9"
 ```
 
 ```diff

--- a/crates/atty-compat/Cargo.toml
+++ b/crates/atty-compat/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "atty"
+version = "0.2.15"
+edition = "2021"
+rust-version = "1.74"
+license = "MIT"
+description = "Sound compatibility implementation of the atty 0.2 API"
+publish = false
+
+[lib]
+path = "src/lib.rs"

--- a/crates/atty-compat/src/lib.rs
+++ b/crates/atty-compat/src/lib.rs
@@ -1,0 +1,48 @@
+//! Sound compatibility implementation of the small `atty` 0.2 API.
+//!
+//! This crate exists only for the legacy Clap 2 dependency used by the
+//! dudect benchmark harness. Rust's standard library has provided the
+//! required terminal detection since Rust 1.70.
+
+#![forbid(unsafe_code)]
+
+use std::io::{self, IsTerminal};
+
+/// Standard stream whose terminal state should be queried.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Stream {
+    /// Standard input.
+    Stdin,
+    /// Standard output.
+    Stdout,
+    /// Standard error.
+    Stderr,
+}
+
+/// Returns whether the selected standard stream is connected to a terminal.
+#[must_use]
+pub fn is(stream: Stream) -> bool {
+    match stream {
+        Stream::Stdin => io::stdin().is_terminal(),
+        Stream::Stdout => io::stdout().is_terminal(),
+        Stream::Stderr => io::stderr().is_terminal(),
+    }
+}
+
+/// Returns whether the selected standard stream is not a terminal.
+#[must_use]
+pub fn isnt(stream: Stream) -> bool {
+    !is(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_and_isnt_are_complements_for_every_stream() {
+        for stream in [Stream::Stdin, Stream::Stdout, Stream::Stderr] {
+            assert_ne!(is(stream), isnt(stream));
+        }
+    }
+}

--- a/crates/kyberlib-hybrid/Cargo.toml
+++ b/crates/kyberlib-hybrid/Cargo.toml
@@ -42,7 +42,7 @@ secp384r1    = []
 # the workspace build uses — `cargo deny`'s wildcards check rejects
 # unversioned path deps, and `cargo publish` requires the version
 # stamp to be present on the manifest.
-kyberlib = { path = "../kyberlib", version = "0.0.8", default-features = false, features = ["kyber768"] }
+kyberlib = { path = "../kyberlib", version = "0.0.9", default-features = false, features = ["kyber768"] }
 # X25519 classical KEM. Activated only when the `x25519` feature is on.
 x25519-dalek = { workspace = true, optional = true }
 rand_core    = { workspace = true }

--- a/crates/kyberlib-pkcs8/Cargo.toml
+++ b/crates/kyberlib-pkcs8/Cargo.toml
@@ -26,7 +26,7 @@ pem     = []   # Will pull in pem-rfc7468 when activated.
 
 [dependencies]
 # See note on the same dep in `kyberlib-hybrid/Cargo.toml`.
-kyberlib = { path = "../kyberlib", version = "0.0.8", default-features = false, features = ["kyber768"] }
+kyberlib = { path = "../kyberlib", version = "0.0.9", default-features = false, features = ["kyber768"] }
 
 [lints]
 workspace = true

--- a/crates/kyberlib-wasm/Cargo.toml
+++ b/crates/kyberlib-wasm/Cargo.toml
@@ -32,7 +32,7 @@ path       = "src/lib.rs"
 
 [dependencies]
 # See note on the same dep in `kyberlib-hybrid/Cargo.toml`.
-kyberlib     = { path = "../kyberlib", version = "0.0.8", default-features = false, features = ["kyber768"] }
+kyberlib     = { path = "../kyberlib", version = "0.0.9", default-features = false, features = ["kyber768"] }
 rand_core    = { workspace = true }
 rand         = { workspace = true, features = ["getrandom"] }
 wasm-bindgen = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -27,14 +27,6 @@ ignore = [
     # No security impact (rendering-layer crate). Re-evaluate when our
     # dev-deps' major versions drop the dependency.
     { id = "RUSTSEC-2021-0139", reason = "transitive dev-dep only; no runtime exposure" },
-    # atty unmaintained — same situation as ansi_term, replaced by
-    # std::io::IsTerminal since Rust 1.70 but transitive dev-deps still
-    # carry it.
-    { id = "RUSTSEC-2024-0375", reason = "transitive dev-dep only; no runtime exposure" },
-    # atty potential-unaligned-read (unsound) — Windows-only path; we
-    # don't ship Windows binaries from this crate, and the dev-dep path
-    # doesn't expose the vulnerable function.
-    { id = "RUSTSEC-2021-0145", reason = "Windows-only, transitive dev-dep only" },
 ]
 
 # ---------------------------------------------------------------------------- licenses


### PR DESCRIPTION
## Summary
- replace vulnerable atty with a sound Rust 1.74 compatibility implementation
- update anyhow and pin zeroize_derive for the declared MSRV
- include the pending taiki-e/install-action update
- align workspace and inter-crate versions on 0.0.9

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo +1.74.0 check -p kyberlib --locked
- cargo-audit audit
- cargo-deny check
- cargo-machete