### PR TITLE
chore(deps): take the cc and clap bumps, hold zeroize at the MSRV

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,16 @@ updates:
     labels: ["dependencies", "rust"]
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # zeroize 1.9 and zeroize_derive 1.5 ship as edition 2024,
+      # which needs Rust >= 1.85. This crate declares rust-version
+      # 1.74, so taking them makes the MSRV job fail at manifest
+      # parse time -- before compiling a single line. Unpin these
+      # when the MSRV is raised deliberately, not to clear a bump.
+      - dependency-name: "zeroize"
+        versions: [">=1.9"]
+      - dependency-name: "zeroize_derive"
+        versions: [">=1.5"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,18 +1904,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.9.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.5.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -357,7 +357,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.6.4",
+ "clap 4.6.6",
  "criterion-plot",
  "is-terminal",
  "itertools",
@@ -556,9 +556,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fnv"
@@ -1879,7 +1879,7 @@ dependencies = [
 name = "xtask"
 version = "0.0.1"
 dependencies = [
- "clap 4.6.4",
+ "clap 4.6.6",
 ]
 
 [[package]]
@@ -1904,18 +1904,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Replaces #229, which could not be merged as-is.

## The group bundled a bump that breaks the MSRV

`zeroize` 1.9.0 and `zeroize_derive` 1.5.0 ship as **edition 2024**, which requires Rust ≥ 1.85. This crate declares `rust-version = "1.74"`, so the MSRV job fails while *parsing the manifest* — before compiling a single line:

```
failed to parse manifest at .../zeroize-1.9.0/Cargo.toml
this version of Cargo is older than the `2024` edition,
and only supports `2015`, `2018`, and `2021` editions.
```

The other two updates in the group are fine and are kept:

| crate | from | to | taken |
|---|---|---|---|
| `cc` | 1.4.0 | 1.4.2 | ✅ |
| `clap` | 4.6.4 | 4.6.6 | ✅ |
| `zeroize` | 1.8.2 | 1.9.0 | ❌ held |
| `zeroize_derive` | 1.4.2 | 1.5.0 | ❌ held |

## Pinning `zeroize` alone was not enough

`zeroize_derive` is a separate package with its own edition. The first attempt held `zeroize` and the MSRV check *still* failed, on the derive crate. Both are pinned here.

Verified by running the CI step locally against 1.74.0 — including its lockfile-version rewrite — rather than inferring it:

```
$ perl -0pi -e 's/^version = 4$/version = 3/m' Cargo.lock
$ cargo +1.74.0 check -p kyberlib --locked
exit=0
```

## Holding `zeroize` back is safe

The only advisory in this family is **RUSTSEC-2021-0115** against `zeroize_derive`, patched in `>= 1.1.1`. The lock carries **1.4.2**, so pinning does not reintroduce it. Checked against the advisory database rather than assumed — worth doing explicitly for a post-quantum crypto crate.

## Why an ignore rather than an MSRV raise

`dependabot.yml` now records the constraint so this is not re-proposed weekly. Raising the MSRV to 1.85 would also make it green — and would narrow what consumers of a cryptography library can build with. That should be a deliberate decision with its own reasoning, not a side effect of clearing a dependency bump. The ignore carries a comment saying exactly that, and to unpin when the MSRV is raised on purpose.