### PR TITLE
ci(release): publish to crates.io via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,6 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write       # GitHub Release creation
+      id-token: write       # OIDC token for crates.io trusted publishing
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
@@ -268,9 +269,18 @@ jobs:
           name: release-artefacts
           path: dist/
 
+      # Trusted publishing: swaps this job's GitHub OIDC identity for a
+      # temporary crates.io token, revoked by the action's post step when
+      # the job ends. Needs a trusted publisher on crates.io for BOTH
+      # kyberlib and kyberlib-wasm -- the config is per crate, and this
+      # step publishes two.
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           # Publish in dependency order. Each cargo-publish call honours
           # crates.io rate limits and waits for indexing where needed.


### PR DESCRIPTION
Replaces the stored crates.io token with an OIDC exchange. crates.io
issues a short-lived token and the auth action's post step revokes it
when the job ends. Nothing is stored, so there is nothing to rotate and
nothing to leak.

The publish job gains `id-token: write`, and the registry token now
comes from the auth action's output rather than repository secrets.

Trusted publishing is configured **per crate**, and this workflow
publishes 2 (kyberlib, kyberlib-wasm). Every one needs its own trusted publisher on
crates.io: repository owner sebastienrousseau, workflow release.yml,
no environment. Releases here are tag-triggered, so merging ahead of that
configuration changes nothing until the next tag is pushed.

actionlint reports no new findings.


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)